### PR TITLE
feat: M2 Map Pipeline

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -21,14 +21,38 @@
       #app {
         width: 100%;
         height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        position: relative;
+      }
+      canvas {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      #loading {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 1.5rem;
+        z-index: 10;
+        pointer-events: none;
+      }
+      #info {
+        position: absolute;
+        bottom: 12px;
+        left: 12px;
+        font-size: 0.85rem;
+        opacity: 0.7;
+        z-index: 10;
+        pointer-events: none;
       }
     </style>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <div id="loading">Loading map...</div>
+      <div id="info"></div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "msgpackr": "^1.11.9",
     "three": "^0.170.0"
   },
   "devDependencies": {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,14 +1,110 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { loadMap, buildScene } from './map';
+import type { BBox } from './map';
+
+// Default bbox: central London (near Trafalgar Square area)
+const DEFAULT_BBOX: BBox = {
+  south: 51.505,
+  west: -0.130,
+  north: 51.515,
+  east: -0.115,
+};
+
 const app = document.getElementById('app')!;
+const loadingEl = document.getElementById('loading')!;
+const infoEl = document.getElementById('info')!;
 
 async function init() {
+  // Setup renderer
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  app.appendChild(renderer.domElement);
+
+  // Setup scene
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x87ceeb); // Sky blue
+
+  // Setup camera (top-down perspective, looking at center)
+  const camera = new THREE.PerspectiveCamera(
+    60,
+    window.innerWidth / window.innerHeight,
+    1,
+    5000
+  );
+  camera.position.set(0, 400, 300);
+  camera.lookAt(0, 0, 0);
+
+  // OrbitControls for camera inspection
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.1;
+  controls.maxPolarAngle = Math.PI / 2.1; // Don't go below ground
+  controls.minDistance = 50;
+  controls.maxDistance = 2000;
+  controls.target.set(0, 0, 0);
+
+  // Lighting
+  const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
+  scene.add(ambientLight);
+
+  const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+  dirLight.position.set(200, 400, 200);
+  dirLight.castShadow = true;
+  dirLight.shadow.mapSize.width = 2048;
+  dirLight.shadow.mapSize.height = 2048;
+  dirLight.shadow.camera.near = 1;
+  dirLight.shadow.camera.far = 1500;
+  dirLight.shadow.camera.left = -500;
+  dirLight.shadow.camera.right = 500;
+  dirLight.shadow.camera.top = 500;
+  dirLight.shadow.camera.bottom = -500;
+  scene.add(dirLight);
+
+  // Hemisphere light for sky/ground color blending
+  const hemiLight = new THREE.HemisphereLight(0x87ceeb, 0x4a7c3f, 0.3);
+  scene.add(hemiLight);
+
+  // Handle resize
+  window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+
+  // Render loop
+  function animate() {
+    requestAnimationFrame(animate);
+    controls.update();
+    renderer.render(scene, camera);
+  }
+  animate();
+
+  // Load map data
   try {
-    const response = await fetch('/api/ping');
-    const data = await response.json();
-    app.textContent = `Server status: ${data.status}`;
-    console.log('Server ping:', data);
-  } catch {
-    app.textContent = 'Real Micro Machines - Server not connected';
-    console.log('Server not available, running in standalone mode');
+    loadingEl.textContent = 'Fetching map data...';
+    const mapData = await loadMap(DEFAULT_BBOX);
+
+    loadingEl.textContent = 'Building 3D scene...';
+    const mapGroup = buildScene(mapData);
+    scene.add(mapGroup);
+
+    // Update info
+    infoEl.textContent = `${mapData.roads.length} roads, ${mapData.buildings.length} buildings, ${mapData.parks.length} parks, ${mapData.water.length} water`;
+
+    // Hide loading
+    loadingEl.style.display = 'none';
+
+    console.log(
+      `Map loaded: ${mapData.roads.length} roads, ${mapData.buildings.length} buildings`
+    );
+  } catch (error) {
+    console.error('Failed to load map:', error);
+    loadingEl.textContent = `Failed to load map: ${error instanceof Error ? error.message : 'Unknown error'}`;
+    loadingEl.style.color = '#ff6666';
   }
 }
 

--- a/client/src/map/BuildingBuilder.test.ts
+++ b/client/src/map/BuildingBuilder.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { buildBuildings } from './BuildingBuilder';
+import { Projection } from './Projection';
+import type { BBox, Building } from './types';
+
+const BBOX: BBox = {
+  south: 51.51,
+  west: -0.12,
+  north: 51.52,
+  east: -0.11,
+};
+
+function makeBuilding(id: number): Building {
+  return {
+    id,
+    footprint: [
+      { lat: 51.511, lon: -0.117 },
+      { lat: 51.511, lon: -0.116 },
+      { lat: 51.512, lon: -0.116 },
+      { lat: 51.512, lon: -0.117 },
+    ],
+    height: 10,
+  };
+}
+
+describe('BuildingBuilder', () => {
+  it('builds a single merged mesh from buildings', () => {
+    const proj = new Projection(BBOX);
+    const mesh = buildBuildings([makeBuilding(1), makeBuilding(2)], proj);
+    expect(mesh).not.toBeNull();
+    expect(mesh!.name).toBe('buildings');
+  });
+
+  it('returns null for empty buildings', () => {
+    const proj = new Projection(BBOX);
+    const mesh = buildBuildings([], proj);
+    expect(mesh).toBeNull();
+  });
+
+  it('single draw call (one mesh)', () => {
+    const proj = new Projection(BBOX);
+    const mesh = buildBuildings(
+      [makeBuilding(1), makeBuilding(2), makeBuilding(3)],
+      proj
+    );
+    expect(mesh).not.toBeNull();
+    // It's a single Mesh, not a Group — one draw call
+    expect(mesh!.type).toBe('Mesh');
+  });
+
+  it('mesh has geometry with vertices', () => {
+    const proj = new Projection(BBOX);
+    const mesh = buildBuildings([makeBuilding(1)], proj);
+    expect(mesh).not.toBeNull();
+    const pos = mesh!.geometry.getAttribute('position');
+    expect(pos.count).toBeGreaterThan(0);
+  });
+});

--- a/client/src/map/BuildingBuilder.ts
+++ b/client/src/map/BuildingBuilder.ts
@@ -1,0 +1,90 @@
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { Projection } from './Projection';
+import type { Building } from './types';
+
+const BUILDING_COLOR = 0xc8b8a8; // Warm gray
+
+/**
+ * Build a single building geometry from its footprint and height.
+ * Uses ExtrudeGeometry to extrude the footprint upward.
+ */
+function buildBuildingGeometry(
+  footprint: { x: number; z: number }[],
+  height: number
+): THREE.BufferGeometry | null {
+  if (footprint.length < 3) return null;
+
+  // Create a 2D shape from the footprint (using X, Z as the shape coordinates)
+  const shape = new THREE.Shape();
+  shape.moveTo(footprint[0].x, footprint[0].z);
+  for (let i = 1; i < footprint.length; i++) {
+    shape.lineTo(footprint[i].x, footprint[i].z);
+  }
+  shape.closePath();
+
+  // Check if the shape has non-zero area (avoid degenerate shapes)
+  const points = shape.getPoints();
+  if (points.length < 3) return null;
+
+  // Calculate signed area to check for degenerate shapes
+  let area = 0;
+  for (let i = 0; i < points.length; i++) {
+    const j = (i + 1) % points.length;
+    area += points[i].x * points[j].y;
+    area -= points[j].x * points[i].y;
+  }
+  if (Math.abs(area) < 0.01) return null;
+
+  // Extrude upward
+  const extrudeSettings: THREE.ExtrudeGeometryOptions = {
+    depth: height,
+    bevelEnabled: false,
+  };
+
+  const geometry = new THREE.ExtrudeGeometry(shape, extrudeSettings);
+
+  // The ExtrudeGeometry extrudes along Z by default.
+  // We need to rotate it so the extrusion goes along Y (up).
+  // The shape is in XZ plane, extrusion goes along the shape's normal.
+  // We created the shape in XZ, so extrusion goes along Y already IF
+  // we rotate the geometry: swap Y and Z of the extrusion.
+  geometry.rotateX(-Math.PI / 2);
+
+  return geometry;
+}
+
+/**
+ * Build all buildings as a single merged mesh for draw-call optimization.
+ */
+export function buildBuildings(
+  buildings: Building[],
+  proj: Projection
+): THREE.Mesh | null {
+  const geometries: THREE.BufferGeometry[] = [];
+
+  for (const building of buildings) {
+    const projected = proj.projectAll(building.footprint);
+    const geom = buildBuildingGeometry(projected, building.height);
+    if (geom) {
+      geometries.push(geom);
+    }
+  }
+
+  if (geometries.length === 0) return null;
+
+  const merged =
+    geometries.length === 1 ? geometries[0] : mergeGeometries(geometries);
+  if (!merged) return null;
+
+  const material = new THREE.MeshStandardMaterial({
+    color: BUILDING_COLOR,
+    roughness: 0.8,
+    metalness: 0.1,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(merged, material);
+  mesh.name = 'buildings';
+  return mesh;
+}

--- a/client/src/map/MapLoader.ts
+++ b/client/src/map/MapLoader.ts
@@ -1,0 +1,66 @@
+import { unpack } from 'msgpackr';
+import * as THREE from 'three';
+import { buildBuildings } from './BuildingBuilder';
+import { buildNature } from './NatureBuilder';
+import { Projection } from './Projection';
+import { buildRoads } from './RoadBuilder';
+import { buildTerrain } from './TerrainBuilder';
+import type { BBox, MapData } from './types';
+import { buildWater } from './WaterBuilder';
+
+/**
+ * Fetch map data from the server's /api/map endpoint.
+ * Returns parsed MapData decoded from MessagePack.
+ */
+export async function loadMap(bbox: BBox): Promise<MapData> {
+  const url = `/api/map?south=${bbox.south}&west=${bbox.west}&north=${bbox.north}&east=${bbox.east}`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ error: 'Unknown error' }));
+    throw new Error(
+      `Failed to load map: ${response.status} - ${error.error || 'Unknown error'}`
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+  const data = unpack(new Uint8Array(buffer)) as MapData;
+  return data;
+}
+
+/**
+ * Build the complete Three.js scene from map data.
+ * Orchestrates all geometry builders.
+ */
+export function buildScene(data: MapData): THREE.Group {
+  const group = new THREE.Group();
+  group.name = 'map';
+
+  const proj = new Projection(data.bbox);
+
+  // Terrain (ground plane) — rendered first, at Y=0
+  const terrain = buildTerrain(data.bbox, proj);
+  group.add(terrain);
+
+  // Water — at Y=-0.1
+  const water = buildWater(data.water, proj);
+  group.add(water);
+
+  // Nature (parks, forests, trees) — ground at Y=0.01, trees above
+  const nature = buildNature(data.parks, data.forests, proj);
+  group.add(nature);
+
+  // Roads — at Y=0.05
+  const roads = buildRoads(data.roads, proj);
+  group.add(roads);
+
+  // Buildings — extruded upward from Y=0
+  const buildings = buildBuildings(data.buildings, proj);
+  if (buildings) {
+    group.add(buildings);
+  }
+
+  return group;
+}

--- a/client/src/map/NatureBuilder.ts
+++ b/client/src/map/NatureBuilder.ts
@@ -1,0 +1,208 @@
+import * as THREE from 'three';
+import { Projection } from './Projection';
+import type { MapPolygon } from './types';
+
+const TREE_TRUNK_COLOR = 0x8b6914;
+const TREE_CROWN_COLOR = 0x2d5a27;
+const PARK_GROUND_COLOR = 0x5a8a4f;
+
+/** Simple polygon bounds check using ray casting. */
+function pointInPolygon(
+  x: number,
+  z: number,
+  polygon: { x: number; z: number }[]
+): boolean {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const zi = polygon[i].z;
+    const xj = polygon[j].x;
+    const zj = polygon[j].z;
+    if (zi > z !== zj > z && x < ((xj - xi) * (z - zi)) / (zj - zi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/** Get bounding box of projected polygon. */
+function polygonBounds(polygon: { x: number; z: number }[]): {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+} {
+  let minX = Infinity,
+    maxX = -Infinity;
+  let minZ = Infinity,
+    maxZ = -Infinity;
+  for (const p of polygon) {
+    minX = Math.min(minX, p.x);
+    maxX = Math.max(maxX, p.x);
+    minZ = Math.min(minZ, p.z);
+    maxZ = Math.max(maxZ, p.z);
+  }
+  return { minX, maxX, minZ, maxZ };
+}
+
+/**
+ * Simple Poisson-like placement using grid-based rejection sampling.
+ * Returns positions within the polygon at roughly the given density.
+ */
+function samplePointsInPolygon(
+  polygon: { x: number; z: number }[],
+  spacing: number,
+  maxPoints: number = 500
+): { x: number; z: number }[] {
+  const bounds = polygonBounds(polygon);
+  const points: { x: number; z: number }[] = [];
+
+  // Add jitter to grid for more natural placement
+  for (let x = bounds.minX; x <= bounds.maxX; x += spacing) {
+    for (let z = bounds.minZ; z <= bounds.maxZ; z += spacing) {
+      if (points.length >= maxPoints) return points;
+
+      // Add random jitter (±40% of spacing)
+      const jitterX = (Math.random() - 0.5) * spacing * 0.8;
+      const jitterZ = (Math.random() - 0.5) * spacing * 0.8;
+      const px = x + jitterX;
+      const pz = z + jitterZ;
+
+      if (pointInPolygon(px, pz, polygon)) {
+        points.push({ x: px, z: pz });
+      }
+    }
+  }
+
+  return points;
+}
+
+/**
+ * Build trees as InstancedMesh for performance.
+ * Each tree is a cone (trunk) + sphere (crown).
+ */
+function buildTrees(
+  positions: { x: number; z: number }[]
+): THREE.Group {
+  const group = new THREE.Group();
+  if (positions.length === 0) return group;
+
+  // Tree trunk: thin cylinder
+  const trunkGeom = new THREE.CylinderGeometry(0.3, 0.4, 2, 6);
+  const trunkMat = new THREE.MeshStandardMaterial({
+    color: TREE_TRUNK_COLOR,
+    roughness: 0.9,
+  });
+  const trunks = new THREE.InstancedMesh(trunkGeom, trunkMat, positions.length);
+
+  // Tree crown: cone
+  const crownGeom = new THREE.ConeGeometry(2, 4, 6);
+  const crownMat = new THREE.MeshStandardMaterial({
+    color: TREE_CROWN_COLOR,
+    roughness: 0.8,
+  });
+  const crowns = new THREE.InstancedMesh(crownGeom, crownMat, positions.length);
+
+  const matrix = new THREE.Matrix4();
+
+  for (let i = 0; i < positions.length; i++) {
+    const { x, z } = positions[i];
+    // Random scale variation (0.7 to 1.3)
+    const scale = 0.7 + Math.random() * 0.6;
+
+    // Trunk: positioned at base
+    matrix.makeTranslation(x, 1 * scale, z);
+    matrix.scale(new THREE.Vector3(scale, scale, scale));
+    trunks.setMatrixAt(i, matrix);
+
+    // Crown: positioned above trunk
+    matrix.makeTranslation(x, 4 * scale, z);
+    matrix.scale(new THREE.Vector3(scale, scale, scale));
+    crowns.setMatrixAt(i, matrix);
+  }
+
+  trunks.instanceMatrix.needsUpdate = true;
+  crowns.instanceMatrix.needsUpdate = true;
+  trunks.name = 'tree-trunks';
+  crowns.name = 'tree-crowns';
+
+  group.add(trunks);
+  group.add(crowns);
+  return group;
+}
+
+/**
+ * Build park/forest ground planes.
+ */
+function buildParkGround(
+  polygon: { x: number; z: number }[]
+): THREE.Mesh | null {
+  if (polygon.length < 3) return null;
+
+  const shape = new THREE.Shape();
+  shape.moveTo(polygon[0].x, polygon[0].z);
+  for (let i = 1; i < polygon.length; i++) {
+    shape.lineTo(polygon[i].x, polygon[i].z);
+  }
+  shape.closePath();
+
+  const geometry = new THREE.ShapeGeometry(shape);
+  geometry.rotateX(-Math.PI / 2);
+
+  const material = new THREE.MeshStandardMaterial({
+    color: PARK_GROUND_COLOR,
+    roughness: 0.95,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.y = 0.01; // Just above terrain
+  return mesh;
+}
+
+/**
+ * Build nature elements (trees in parks/forests, ground planes).
+ */
+export function buildNature(
+  parks: MapPolygon[],
+  forests: MapPolygon[],
+  proj: Projection
+): THREE.Group {
+  const group = new THREE.Group();
+  group.name = 'nature';
+
+  const allTreePositions: { x: number; z: number }[] = [];
+
+  // Parks: lower tree density, with ground plane
+  for (const park of parks) {
+    const projected = proj.projectAll(park.points);
+    if (projected.length < 3) continue;
+
+    // Park ground
+    const ground = buildParkGround(projected);
+    if (ground) group.add(ground);
+
+    // Trees in parks (1 per ~100m² → spacing ~10m)
+    const positions = samplePointsInPolygon(projected, 10, 200);
+    allTreePositions.push(...positions);
+  }
+
+  // Forests: higher tree density, no separate ground
+  for (const forest of forests) {
+    const projected = proj.projectAll(forest.points);
+    if (projected.length < 3) continue;
+
+    // Trees in forests (1 per ~50m² → spacing ~7m)
+    const positions = samplePointsInPolygon(projected, 7, 500);
+    allTreePositions.push(...positions);
+  }
+
+  // Build all trees as one instanced group
+  if (allTreePositions.length > 0) {
+    const trees = buildTrees(allTreePositions);
+    trees.name = 'trees';
+    group.add(trees);
+  }
+
+  return group;
+}

--- a/client/src/map/Projection.test.ts
+++ b/client/src/map/Projection.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { Projection } from './Projection';
+import type { BBox, LatLon } from './types';
+
+const LONDON_BBOX: BBox = {
+  south: 51.51,
+  west: -0.12,
+  north: 51.52,
+  east: -0.11,
+};
+
+describe('Projection', () => {
+  it('projects bbox center to (0, 0)', () => {
+    const proj = new Projection(LONDON_BBOX);
+    const center: LatLon = {
+      lat: (LONDON_BBOX.south + LONDON_BBOX.north) / 2,
+      lon: (LONDON_BBOX.west + LONDON_BBOX.east) / 2,
+    };
+    const { x, z } = proj.project(center);
+    expect(Math.abs(x)).toBeLessThan(0.001);
+    expect(Math.abs(z)).toBeLessThan(0.001);
+  });
+
+  it('east is positive X', () => {
+    const proj = new Projection(LONDON_BBOX);
+    const eastPoint: LatLon = { lat: 51.515, lon: -0.10 };
+    const { x } = proj.project(eastPoint);
+    expect(x).toBeGreaterThan(0);
+  });
+
+  it('north is negative Z (Three.js convention)', () => {
+    const proj = new Projection(LONDON_BBOX);
+    const northPoint: LatLon = { lat: 51.525, lon: -0.115 };
+    const { z } = proj.project(northPoint);
+    expect(z).toBeLessThan(0);
+  });
+
+  it('produces expected distances within 1m tolerance', () => {
+    const proj = new Projection(LONDON_BBOX);
+    // ~111m per 0.001 degrees latitude
+    const p1: LatLon = { lat: 51.515, lon: -0.115 };
+    const p2: LatLon = { lat: 51.516, lon: -0.115 };
+    const r1 = proj.project(p1);
+    const r2 = proj.project(p2);
+    const dist = Math.abs(r2.z - r1.z);
+    // 0.001 degrees latitude ≈ 111.3m
+    expect(dist).toBeGreaterThan(110);
+    expect(dist).toBeLessThan(113);
+  });
+
+  it('symmetry: equidistant north/south have equal |z|', () => {
+    const proj = new Projection(LONDON_BBOX);
+    const center = (LONDON_BBOX.south + LONDON_BBOX.north) / 2;
+    const offset = 0.002;
+    const north: LatLon = { lat: center + offset, lon: -0.115 };
+    const south: LatLon = { lat: center - offset, lon: -0.115 };
+    const rn = proj.project(north);
+    const rs = proj.project(south);
+    expect(Math.abs(Math.abs(rn.z) - Math.abs(rs.z))).toBeLessThan(0.01);
+  });
+
+  it('projectAll returns correct count', () => {
+    const proj = new Projection(LONDON_BBOX);
+    const points: LatLon[] = [
+      { lat: 51.511, lon: -0.116 },
+      { lat: 51.512, lon: -0.115 },
+      { lat: 51.513, lon: -0.114 },
+    ];
+    const projected = proj.projectAll(points);
+    expect(projected).toHaveLength(3);
+  });
+
+  it('bboxSizeMeters returns reasonable values for London', () => {
+    const proj = new Projection(LONDON_BBOX);
+    const { width, height } = proj.bboxSizeMeters(LONDON_BBOX);
+    // ~0.01 degrees lat ≈ 1113m, ~0.01 degrees lon at 51.5° ≈ 695m
+    expect(height).toBeGreaterThan(1000);
+    expect(height).toBeLessThan(1200);
+    expect(width).toBeGreaterThan(600);
+    expect(width).toBeLessThan(800);
+  });
+});

--- a/client/src/map/Projection.ts
+++ b/client/src/map/Projection.ts
@@ -1,0 +1,46 @@
+import type { BBox, LatLon } from './types';
+
+const DEG2RAD = Math.PI / 180;
+const METERS_PER_DEGREE = 111_320;
+
+/**
+ * Projects lat/lon coordinates to local XZ meters using a
+ * local tangent plane projection centered on the bbox center.
+ *
+ * - X axis: east (positive) / west (negative)
+ * - Z axis: south (positive) / north (negative) — Three.js convention
+ * - Y axis: up (handled by builders, not projection)
+ */
+export class Projection {
+  readonly centerLat: number;
+  readonly centerLon: number;
+  private readonly cosLat: number;
+
+  constructor(bbox: BBox) {
+    this.centerLat = (bbox.south + bbox.north) / 2;
+    this.centerLon = (bbox.west + bbox.east) / 2;
+    this.cosLat = Math.cos(this.centerLat * DEG2RAD);
+  }
+
+  /** Project a single lat/lon to local XZ coordinates (meters). */
+  project(point: LatLon): { x: number; z: number } {
+    const x = (point.lon - this.centerLon) * this.cosLat * METERS_PER_DEGREE;
+    const z = -(point.lat - this.centerLat) * METERS_PER_DEGREE;
+    return { x, z };
+  }
+
+  /** Project an array of lat/lon points. */
+  projectAll(points: LatLon[]): { x: number; z: number }[] {
+    return points.map((p) => this.project(p));
+  }
+
+  /** Get the approximate width and height of a bbox in meters. */
+  bboxSizeMeters(bbox: BBox): { width: number; height: number } {
+    const width =
+      (bbox.east - bbox.west) *
+      Math.cos(((bbox.south + bbox.north) / 2) * DEG2RAD) *
+      METERS_PER_DEGREE;
+    const height = (bbox.north - bbox.south) * METERS_PER_DEGREE;
+    return { width, height };
+  }
+}

--- a/client/src/map/RoadBuilder.test.ts
+++ b/client/src/map/RoadBuilder.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { buildRoads } from './RoadBuilder';
+import { Projection } from './Projection';
+import type { BBox, Road } from './types';
+
+const BBOX: BBox = {
+  south: 51.51,
+  west: -0.12,
+  north: 51.52,
+  east: -0.11,
+};
+
+function makeStraightRoad(): Road {
+  return {
+    id: 1,
+    highway_type: 'residential',
+    points: [
+      { lat: 51.511, lon: -0.116 },
+      { lat: 51.512, lon: -0.115 },
+      { lat: 51.513, lon: -0.114 },
+    ],
+    width: 6,
+    name: 'Test Road',
+    oneway: false,
+    lanes: 2,
+  };
+}
+
+describe('RoadBuilder', () => {
+  it('builds a group from roads', () => {
+    const proj = new Projection(BBOX);
+    const group = buildRoads([makeStraightRoad()], proj);
+    expect(group.children.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty group for no roads', () => {
+    const proj = new Projection(BBOX);
+    const group = buildRoads([], proj);
+    expect(group.children.length).toBe(0);
+  });
+
+  it('road mesh has correct geometry structure', () => {
+    const proj = new Projection(BBOX);
+    const group = buildRoads([makeStraightRoad()], proj);
+    const mesh = group.children[0] as THREE.Mesh;
+    const geom = mesh.geometry;
+
+    // 3 points → 2 segments → 4 triangles → 12 indices
+    const index = geom.getIndex();
+    expect(index).not.toBeNull();
+    expect(index!.count).toBe(12); // 2 segments * 2 triangles * 3 vertices
+
+    // 3 points → 6 vertices (left + right per point)
+    const pos = geom.getAttribute('position');
+    expect(pos.count).toBe(6);
+  });
+
+  it('roads with same type are merged', () => {
+    const proj = new Projection(BBOX);
+    const road1 = makeStraightRoad();
+    const road2 = { ...makeStraightRoad(), id: 2, name: 'Another Road' };
+    const group = buildRoads([road1, road2], proj);
+    // Both residential → same color → merged into 1 mesh
+    expect(group.children.length).toBe(1);
+  });
+
+  it('roads with different types are separate meshes', () => {
+    const proj = new Projection(BBOX);
+    const road1 = makeStraightRoad();
+    const road2 = {
+      ...makeStraightRoad(),
+      id: 2,
+      highway_type: 'motorway',
+    };
+    const group = buildRoads([road1, road2], proj);
+    expect(group.children.length).toBe(2);
+  });
+});

--- a/client/src/map/RoadBuilder.ts
+++ b/client/src/map/RoadBuilder.ts
@@ -1,0 +1,164 @@
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { Projection } from './Projection';
+import type { Road } from './types';
+
+/** Road Y position — slightly above ground to prevent z-fighting. */
+const ROAD_Y = 0.05;
+
+/** Color mapping by highway category. */
+function roadColor(highwayType: string): number {
+  switch (highwayType) {
+    case 'motorway':
+    case 'motorway_link':
+      return 0x444444;
+    case 'trunk':
+    case 'trunk_link':
+    case 'primary':
+    case 'primary_link':
+      return 0x555555;
+    case 'secondary':
+    case 'secondary_link':
+    case 'tertiary':
+    case 'tertiary_link':
+      return 0x666666;
+    case 'residential':
+    case 'living_street':
+    case 'unclassified':
+      return 0x888888;
+    case 'service':
+      return 0x999999;
+    case 'footway':
+    case 'cycleway':
+    case 'path':
+    case 'pedestrian':
+      return 0xaaaaaa;
+    default:
+      return 0x777777;
+  }
+}
+
+/**
+ * Build a triangle-strip geometry for a single road polyline.
+ * Generates two triangles per segment with perpendicular width offsets.
+ */
+function buildRoadGeometry(
+  points: { x: number; z: number }[],
+  halfWidth: number
+): THREE.BufferGeometry | null {
+  if (points.length < 2) return null;
+
+  const vertices: number[] = [];
+  const normals: number[] = [];
+
+  for (let i = 0; i < points.length; i++) {
+    // Compute direction at this point (averaged for interior points)
+    let dx = 0;
+    let dz = 0;
+
+    if (i === 0) {
+      dx = points[1].x - points[0].x;
+      dz = points[1].z - points[0].z;
+    } else if (i === points.length - 1) {
+      dx = points[i].x - points[i - 1].x;
+      dz = points[i].z - points[i - 1].z;
+    } else {
+      // Average direction at junction for smooth corners
+      const dx1 = points[i].x - points[i - 1].x;
+      const dz1 = points[i].z - points[i - 1].z;
+      const dx2 = points[i + 1].x - points[i].x;
+      const dz2 = points[i + 1].z - points[i].z;
+      dx = dx1 + dx2;
+      dz = dz1 + dz2;
+    }
+
+    // Normalize
+    const len = Math.sqrt(dx * dx + dz * dz);
+    if (len < 1e-8) continue;
+    dx /= len;
+    dz /= len;
+
+    // Perpendicular direction (rotate 90 degrees)
+    const px = -dz * halfWidth;
+    const pz = dx * halfWidth;
+
+    // Left vertex
+    vertices.push(points[i].x - px, ROAD_Y, points[i].z - pz);
+    normals.push(0, 1, 0);
+
+    // Right vertex
+    vertices.push(points[i].x + px, ROAD_Y, points[i].z + pz);
+    normals.push(0, 1, 0);
+  }
+
+  // Build triangle indices from the strip
+  const numPoints = vertices.length / 3 / 2; // pairs of left/right
+  if (numPoints < 2) return null;
+
+  const indices: number[] = [];
+  for (let i = 0; i < numPoints - 1; i++) {
+    const bl = i * 2;
+    const br = i * 2 + 1;
+    const tl = (i + 1) * 2;
+    const tr = (i + 1) * 2 + 1;
+    // Two triangles per segment
+    indices.push(bl, br, tl);
+    indices.push(br, tr, tl);
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute(vertices, 3)
+  );
+  geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geometry.setIndex(indices);
+  return geometry;
+}
+
+/**
+ * Build all road meshes from map data.
+ * Groups roads by type and merges geometries for draw-call optimization.
+ */
+export function buildRoads(roads: Road[], proj: Projection): THREE.Group {
+  const group = new THREE.Group();
+  group.name = 'roads';
+
+  // Group roads by color
+  const colorGroups = new Map<number, THREE.BufferGeometry[]>();
+
+  for (const road of roads) {
+    const projected = proj.projectAll(road.points);
+    const halfWidth = road.width / 2;
+    const geom = buildRoadGeometry(projected, halfWidth);
+    if (!geom) continue;
+
+    const color = roadColor(road.highway_type);
+    if (!colorGroups.has(color)) {
+      colorGroups.set(color, []);
+    }
+    colorGroups.get(color)!.push(geom);
+  }
+
+  // Merge and create meshes per color group
+  for (const [color, geometries] of colorGroups) {
+    if (geometries.length === 0) continue;
+
+    const merged =
+      geometries.length === 1 ? geometries[0] : mergeGeometries(geometries);
+    if (!merged) continue;
+
+    const material = new THREE.MeshStandardMaterial({
+      color,
+      roughness: 0.9,
+      metalness: 0.0,
+      side: THREE.DoubleSide,
+    });
+
+    const mesh = new THREE.Mesh(merged, material);
+    mesh.name = `roads-${color.toString(16)}`;
+    group.add(mesh);
+  }
+
+  return group;
+}

--- a/client/src/map/TerrainBuilder.ts
+++ b/client/src/map/TerrainBuilder.ts
@@ -1,0 +1,34 @@
+import * as THREE from 'three';
+import { Projection } from './Projection';
+import type { BBox } from './types';
+
+const TERRAIN_COLOR = 0x4a7c3f;
+
+/**
+ * Build a flat green ground plane covering the bbox area.
+ * Extends 10% beyond bbox to avoid visible edges.
+ */
+export function buildTerrain(bbox: BBox, proj: Projection): THREE.Mesh {
+  const { width, height } = proj.bboxSizeMeters(bbox);
+
+  // Add 10% padding on each side
+  const paddedWidth = width * 1.2;
+  const paddedHeight = height * 1.2;
+
+  const geometry = new THREE.PlaneGeometry(paddedWidth, paddedHeight);
+  geometry.rotateX(-Math.PI / 2); // Lay flat (XZ plane)
+
+  const material = new THREE.MeshStandardMaterial({
+    color: TERRAIN_COLOR,
+    roughness: 0.95,
+    metalness: 0.0,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.position.y = 0;
+  mesh.name = 'terrain';
+  mesh.receiveShadow = true;
+
+  return mesh;
+}

--- a/client/src/map/WaterBuilder.ts
+++ b/client/src/map/WaterBuilder.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+import { Projection } from './Projection';
+import type { MapPolygon } from './types';
+
+const WATER_COLOR = 0x4488cc;
+const WATER_Y = -0.1;
+
+/**
+ * Build water polygons as flat semi-transparent planes.
+ */
+export function buildWater(
+  water: MapPolygon[],
+  proj: Projection
+): THREE.Group {
+  const group = new THREE.Group();
+  group.name = 'water';
+
+  for (const poly of water) {
+    const projected = proj.projectAll(poly.points);
+    if (projected.length < 3) continue;
+
+    const shape = new THREE.Shape();
+    shape.moveTo(projected[0].x, projected[0].z);
+    for (let i = 1; i < projected.length; i++) {
+      shape.lineTo(projected[i].x, projected[i].z);
+    }
+    shape.closePath();
+
+    const geometry = new THREE.ShapeGeometry(shape);
+    geometry.rotateX(-Math.PI / 2);
+
+    const material = new THREE.MeshStandardMaterial({
+      color: WATER_COLOR,
+      transparent: true,
+      opacity: 0.7,
+      roughness: 0.3,
+      metalness: 0.1,
+      side: THREE.DoubleSide,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.y = WATER_Y;
+    mesh.name = `water-${poly.id}`;
+    group.add(mesh);
+  }
+
+  return group;
+}

--- a/client/src/map/index.ts
+++ b/client/src/map/index.ts
@@ -1,0 +1,15 @@
+export { Projection } from './Projection';
+export { buildRoads } from './RoadBuilder';
+export { buildBuildings } from './BuildingBuilder';
+export { buildNature } from './NatureBuilder';
+export { buildWater } from './WaterBuilder';
+export { buildTerrain } from './TerrainBuilder';
+export { loadMap, buildScene } from './MapLoader';
+export type {
+  BBox,
+  Building,
+  LatLon,
+  MapData,
+  MapPolygon,
+  Road,
+} from './types';

--- a/client/src/map/types.ts
+++ b/client/src/map/types.ts
@@ -1,0 +1,48 @@
+/** A geographic coordinate. */
+export interface LatLon {
+  lat: number;
+  lon: number;
+}
+
+/** A geographic bounding box. */
+export interface BBox {
+  south: number;
+  west: number;
+  north: number;
+  east: number;
+}
+
+/** A road segment from OSM data. */
+export interface Road {
+  id: number;
+  highway_type: string;
+  points: LatLon[];
+  width: number;
+  name?: string;
+  oneway: boolean;
+  lanes: number;
+}
+
+/** A building from OSM data. */
+export interface Building {
+  id: number;
+  footprint: LatLon[];
+  height: number;
+}
+
+/** A generic polygon (water, park, forest). */
+export interface MapPolygon {
+  id: number;
+  points: LatLon[];
+  polygon_type: string;
+}
+
+/** Complete map data for a region. */
+export interface MapData {
+  roads: Road[];
+  buildings: Building[];
+  water: MapPolygon[];
+  parks: MapPolygon[];
+  forests: MapPolygon[];
+  bbox: BBox;
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "onlyBuiltDependencies": [
       "@swc/core",
       "esbuild",
-      "lefthook"
+      "lefthook",
+      "msgpackr-extract"
     ]
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   client:
     dependencies:
+      msgpackr:
+        specifier: ^1.11.9
+        version: 1.11.9
       three:
         specifier: ^0.170.0
         version: 0.170.0
@@ -458,6 +461,36 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -912,6 +945,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -1202,6 +1239,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.9:
+    resolution: {integrity: sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1209,6 +1253,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1808,6 +1856,24 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
@@ -2199,6 +2265,9 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  detect-libc@2.1.2:
+    optional: true
+
   entities@6.0.1: {}
 
   es-module-lexer@1.7.0: {}
@@ -2534,9 +2603,30 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.9:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   optionator@0.9.4:
     dependencies:

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +94,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +155,35 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -268,6 +312,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -721,6 +775,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,18 +1004,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmm-map"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "rmm-server"
 version = "0.1.0"
 dependencies = [
  "axum",
  "dotenvy",
  "reqwest",
+ "rmm-map",
+ "rmp-serde",
  "serde",
  "serde_json",
  "tokio",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -1124,6 +1222,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1354,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1442,6 +1571,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1623,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/rmm-server"]
+members = ["crates/rmm-server", "crates/rmm-map"]
 
 [workspace.package]
 version = "0.1.0"

--- a/server/crates/rmm-map/Cargo.toml
+++ b/server/crates/rmm-map/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rmm-map"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rmp-serde = "1"
+sha2 = "0.10"
+thiserror = "2"
+tokio = { version = "1", features = ["time", "sync"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/server/crates/rmm-map/src/bbox.rs
+++ b/server/crates/rmm-map/src/bbox.rs
@@ -1,0 +1,138 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::MapError;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct BBox {
+    pub south: f64,
+    pub west: f64,
+    pub north: f64,
+    pub east: f64,
+}
+
+impl BBox {
+    pub fn new(south: f64, west: f64, north: f64, east: f64) -> Result<Self, MapError> {
+        let bbox = Self {
+            south,
+            west,
+            north,
+            east,
+        };
+        bbox.validate()?;
+        Ok(bbox)
+    }
+
+    /// Validate that the bounding box is well-formed.
+    pub fn validate(&self) -> Result<(), MapError> {
+        if self.south >= self.north {
+            return Err(MapError::InvalidBBox(
+                "south must be less than north".into(),
+            ));
+        }
+        if self.west >= self.east {
+            return Err(MapError::InvalidBBox(
+                "west must be less than east".into(),
+            ));
+        }
+        if self.south < -90.0 || self.north > 90.0 {
+            return Err(MapError::InvalidBBox(
+                "latitude must be between -90 and 90".into(),
+            ));
+        }
+        if self.west < -180.0 || self.east > 180.0 {
+            return Err(MapError::InvalidBBox(
+                "longitude must be between -180 and 180".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Approximate side lengths in meters using Haversine-like estimation.
+    pub fn side_lengths_m(&self) -> (f64, f64) {
+        let center_lat = (self.south + self.north) / 2.0;
+        let lat_rad = center_lat.to_radians();
+
+        let ns_meters = (self.north - self.south) * 111_320.0;
+        let ew_meters = (self.east - self.west) * 111_320.0 * lat_rad.cos();
+
+        (ns_meters, ew_meters)
+    }
+
+    /// Check that both sides are within the given range (inclusive).
+    pub fn validate_size(&self, min_m: f64, max_m: f64) -> Result<(), MapError> {
+        let (ns, ew) = self.side_lengths_m();
+        if ns < min_m || ew < min_m {
+            return Err(MapError::InvalidBBox(format!(
+                "bounding box too small: {:.0}m x {:.0}m (minimum {}m)",
+                ns, ew, min_m
+            )));
+        }
+        if ns > max_m || ew > max_m {
+            return Err(MapError::InvalidBBox(format!(
+                "bounding box too large: {:.0}m x {:.0}m (maximum {}m)",
+                ns, ew, max_m
+            )));
+        }
+        Ok(())
+    }
+
+    /// Center point of the bounding box.
+    pub fn center(&self) -> (f64, f64) {
+        (
+            (self.south + self.north) / 2.0,
+            (self.west + self.east) / 2.0,
+        )
+    }
+
+    /// Format as Overpass API bbox string: "south,west,north,east"
+    pub fn to_overpass_string(&self) -> String {
+        format!("{},{},{},{}", self.south, self.west, self.north, self.east)
+    }
+
+    /// Cache key string (6 decimal precision).
+    pub fn cache_key_string(&self) -> String {
+        format!(
+            "{:.6},{:.6},{:.6},{:.6}",
+            self.south, self.west, self.north, self.east
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_bbox() {
+        let bbox = BBox::new(51.51, -0.12, 51.52, -0.11).unwrap();
+        assert!((bbox.south - 51.51).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn invalid_south_north() {
+        let result = BBox::new(51.52, -0.12, 51.51, -0.11);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn side_lengths_reasonable() {
+        let bbox = BBox::new(51.510, -0.120, 51.515, -0.110).unwrap();
+        let (ns, ew) = bbox.side_lengths_m();
+        // ~555m north-south, ~695m east-west at London latitude
+        assert!(ns > 500.0 && ns < 600.0);
+        assert!(ew > 600.0 && ew < 800.0);
+    }
+
+    #[test]
+    fn size_validation() {
+        let bbox = BBox::new(51.510, -0.120, 51.515, -0.110).unwrap();
+        assert!(bbox.validate_size(100.0, 2000.0).is_ok());
+        assert!(bbox.validate_size(1000.0, 2000.0).is_err()); // too small
+    }
+
+    #[test]
+    fn overpass_string_format() {
+        let bbox = BBox::new(51.51, -0.12, 51.52, -0.11).unwrap();
+        assert_eq!(bbox.to_overpass_string(), "51.51,-0.12,51.52,-0.11");
+    }
+}

--- a/server/crates/rmm-map/src/cache.rs
+++ b/server/crates/rmm-map/src/cache.rs
@@ -1,0 +1,243 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use sha2::{Digest, Sha256};
+use tracing::{debug, info, warn};
+
+use crate::bbox::BBox;
+use crate::error::MapError;
+use crate::osm_types::MapData;
+
+const DEFAULT_TTL_SECS: u64 = 7 * 24 * 60 * 60; // 1 week
+
+/// Disk-based cache for MapData using MessagePack serialization.
+#[derive(Clone)]
+pub struct MapCache {
+    cache_dir: PathBuf,
+    ttl: Duration,
+}
+
+impl MapCache {
+    pub fn new(cache_dir: impl AsRef<Path>) -> Self {
+        let cache_dir = cache_dir.as_ref().to_path_buf();
+        Self {
+            cache_dir,
+            ttl: Duration::from_secs(DEFAULT_TTL_SECS),
+        }
+    }
+
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = ttl;
+        self
+    }
+
+    /// Ensure the cache directory exists.
+    pub fn ensure_dir(&self) -> Result<(), MapError> {
+        if !self.cache_dir.exists() {
+            fs::create_dir_all(&self.cache_dir)?;
+            info!("Created cache directory: {}", self.cache_dir.display());
+        }
+        Ok(())
+    }
+
+    /// Generate a deterministic cache key for a bbox.
+    fn cache_key(bbox: &BBox) -> String {
+        let input = bbox.cache_key_string();
+        let hash = Sha256::digest(input.as_bytes());
+        hex::encode(&hash[..16]) // 32-char hex string (128 bits, plenty unique)
+    }
+
+    /// Path to the cache file for a given bbox.
+    fn cache_path(&self, bbox: &BBox) -> PathBuf {
+        self.cache_dir.join(format!("{}.msgpack", Self::cache_key(bbox)))
+    }
+
+    /// Try to get cached MapData for a bbox. Returns None if not cached or expired.
+    pub fn get(&self, bbox: &BBox) -> Option<MapData> {
+        let path = self.cache_path(bbox);
+        if !path.exists() {
+            debug!("Cache miss for bbox {}", bbox.cache_key_string());
+            return None;
+        }
+
+        // Check TTL
+        if let Ok(metadata) = fs::metadata(&path) {
+            if let Ok(modified) = metadata.modified() {
+                if let Ok(elapsed) = SystemTime::now().duration_since(modified) {
+                    if elapsed > self.ttl {
+                        debug!("Cache expired for bbox {}", bbox.cache_key_string());
+                        let _ = fs::remove_file(&path);
+                        return None;
+                    }
+                }
+            }
+        }
+
+        // Deserialize
+        match fs::read(&path) {
+            Ok(data) => match rmp_serde::from_slice::<MapData>(&data) {
+                Ok(map_data) => {
+                    info!("Cache hit for bbox {}", bbox.cache_key_string());
+                    Some(map_data)
+                }
+                Err(e) => {
+                    warn!("Failed to deserialize cache file {}: {}", path.display(), e);
+                    let _ = fs::remove_file(&path);
+                    None
+                }
+            },
+            Err(e) => {
+                warn!("Failed to read cache file {}: {}", path.display(), e);
+                None
+            }
+        }
+    }
+
+    /// Store MapData in the cache.
+    pub fn set(&self, bbox: &BBox, data: &MapData) -> Result<(), MapError> {
+        self.ensure_dir()?;
+        let path = self.cache_path(bbox);
+        let encoded = rmp_serde::to_vec(data)?;
+        fs::write(&path, &encoded)?;
+        debug!(
+            "Cached {} bytes for bbox {}",
+            encoded.len(),
+            bbox.cache_key_string()
+        );
+        Ok(())
+    }
+
+    /// Clear all cached data.
+    pub fn clear(&self) -> Result<(), MapError> {
+        if self.cache_dir.exists() {
+            for entry in fs::read_dir(&self.cache_dir)? {
+                let entry = entry?;
+                if entry.path().extension().map(|e| e == "msgpack").unwrap_or(false) {
+                    fs::remove_file(entry.path())?;
+                }
+            }
+            info!("Cleared cache directory: {}", self.cache_dir.display());
+        }
+        Ok(())
+    }
+}
+
+// We need hex encoding for the cache key — add a tiny inline implementation
+// to avoid pulling in the `hex` crate just for this.
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{:02x}", b)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::osm_types::{Building, LatLon, Road};
+    use std::time::Duration;
+
+    fn sample_map_data(bbox: BBox) -> MapData {
+        MapData {
+            roads: vec![Road {
+                id: 1,
+                highway_type: "residential".into(),
+                points: vec![
+                    LatLon::new(51.51, -0.12),
+                    LatLon::new(51.52, -0.11),
+                ],
+                width: 6.0,
+                name: Some("Test Road".into()),
+                oneway: false,
+                lanes: 2,
+            }],
+            buildings: vec![Building {
+                id: 2,
+                footprint: vec![
+                    LatLon::new(51.511, -0.117),
+                    LatLon::new(51.511, -0.116),
+                    LatLon::new(51.512, -0.116),
+                    LatLon::new(51.511, -0.117),
+                ],
+                height: 12.0,
+            }],
+            water: vec![],
+            parks: vec![],
+            forests: vec![],
+            bbox,
+        }
+    }
+
+    #[test]
+    fn write_and_read_cache() {
+        let dir = std::env::temp_dir().join("rmm-map-cache-test");
+        let _ = fs::remove_dir_all(&dir);
+
+        let cache = MapCache::new(&dir);
+        let bbox = BBox::new(51.510, -0.120, 51.515, -0.110).unwrap();
+        let data = sample_map_data(bbox);
+
+        // Cache miss initially
+        assert!(cache.get(&bbox).is_none());
+
+        // Write
+        cache.set(&bbox, &data).unwrap();
+
+        // Cache hit
+        let cached = cache.get(&bbox).unwrap();
+        assert_eq!(cached.roads.len(), 1);
+        assert_eq!(cached.buildings.len(), 1);
+        assert_eq!(cached.roads[0].name.as_deref(), Some("Test Road"));
+
+        // Cleanup
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn expired_entries_are_ignored() {
+        let dir = std::env::temp_dir().join("rmm-map-cache-ttl-test");
+        let _ = fs::remove_dir_all(&dir);
+
+        let cache = MapCache::new(&dir).with_ttl(Duration::from_secs(0));
+        let bbox = BBox::new(51.510, -0.120, 51.515, -0.110).unwrap();
+        let data = sample_map_data(bbox);
+
+        cache.set(&bbox, &data).unwrap();
+
+        // With TTL=0, everything is expired
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(cache.get(&bbox).is_none());
+
+        // Cleanup
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clear_removes_files() {
+        let dir = std::env::temp_dir().join("rmm-map-cache-clear-test");
+        let _ = fs::remove_dir_all(&dir);
+
+        let cache = MapCache::new(&dir);
+        let bbox = BBox::new(51.510, -0.120, 51.515, -0.110).unwrap();
+        let data = sample_map_data(bbox);
+
+        cache.set(&bbox, &data).unwrap();
+        assert!(cache.get(&bbox).is_some());
+
+        cache.clear().unwrap();
+        assert!(cache.get(&bbox).is_none());
+
+        // Cleanup
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn different_bbox_different_key() {
+        let bbox1 = BBox::new(51.510, -0.120, 51.515, -0.110).unwrap();
+        let bbox2 = BBox::new(51.511, -0.120, 51.515, -0.110).unwrap();
+
+        let key1 = MapCache::cache_key(&bbox1);
+        let key2 = MapCache::cache_key(&bbox2);
+        assert_ne!(key1, key2);
+    }
+}

--- a/server/crates/rmm-map/src/error.rs
+++ b/server/crates/rmm-map/src/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MapError {
+    #[error("Overpass API request failed: {0}")]
+    OverpassRequest(#[from] reqwest::Error),
+
+    #[error("Overpass API returned error: {0}")]
+    OverpassResponse(String),
+
+    #[error("Failed to parse Overpass JSON: {0}")]
+    ParseError(String),
+
+    #[error("Invalid bounding box: {0}")]
+    InvalidBBox(String),
+
+    #[error("Cache I/O error: {0}")]
+    CacheError(#[from] std::io::Error),
+
+    #[error("MessagePack encode error: {0}")]
+    MsgpackEncode(#[from] rmp_serde::encode::Error),
+
+    #[error("MessagePack decode error: {0}")]
+    MsgpackDecode(#[from] rmp_serde::decode::Error),
+
+    #[error("Rate limited: please wait before making another request")]
+    RateLimited,
+
+    #[error("Request timed out after {0} seconds")]
+    Timeout(u64),
+}

--- a/server/crates/rmm-map/src/lib.rs
+++ b/server/crates/rmm-map/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod bbox;
+pub mod cache;
+pub mod error;
+pub mod osm_types;
+pub mod overpass;
+pub mod parser;
+
+pub use bbox::BBox;
+pub use cache::MapCache;
+pub use error::MapError;
+pub use osm_types::{Building, LatLon, MapData, Polygon, Road};
+pub use overpass::OverpassClient;
+pub use parser::parse_overpass_json;

--- a/server/crates/rmm-map/src/osm_types.rs
+++ b/server/crates/rmm-map/src/osm_types.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+use crate::bbox::BBox;
+
+/// All map data for a bounding box region.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MapData {
+    pub roads: Vec<Road>,
+    pub buildings: Vec<Building>,
+    pub water: Vec<Polygon>,
+    pub parks: Vec<Polygon>,
+    pub forests: Vec<Polygon>,
+    pub bbox: BBox,
+}
+
+/// A road segment parsed from OSM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Road {
+    pub id: i64,
+    pub highway_type: String,
+    pub points: Vec<LatLon>,
+    /// Estimated road width in meters based on highway type.
+    pub width: f64,
+    pub name: Option<String>,
+    pub oneway: bool,
+    pub lanes: u8,
+}
+
+/// A building parsed from OSM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Building {
+    pub id: i64,
+    pub footprint: Vec<LatLon>,
+    /// Estimated height in meters (from height tag, levels*3, or default 8m).
+    pub height: f64,
+}
+
+/// A generic polygon (water, park, forest).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Polygon {
+    pub id: i64,
+    pub points: Vec<LatLon>,
+    pub polygon_type: String,
+}
+
+/// A geographic coordinate.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct LatLon {
+    pub lat: f64,
+    pub lon: f64,
+}
+
+impl LatLon {
+    pub fn new(lat: f64, lon: f64) -> Self {
+        Self { lat, lon }
+    }
+}

--- a/server/crates/rmm-map/src/overpass.rs
+++ b/server/crates/rmm-map/src/overpass.rs
@@ -1,0 +1,143 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::Client;
+use tokio::sync::Semaphore;
+use tracing::{debug, info, warn};
+
+use crate::bbox::BBox;
+use crate::error::MapError;
+
+const OVERPASS_API_URL: &str = "https://overpass-api.de/api/interpreter";
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+const RATE_LIMIT_DELAY_SECS: u64 = 2;
+
+/// Client for fetching map data from the Overpass API.
+#[derive(Clone)]
+pub struct OverpassClient {
+    client: Client,
+    /// Semaphore to enforce rate limiting (max 1 concurrent request).
+    semaphore: Arc<Semaphore>,
+}
+
+impl OverpassClient {
+    pub fn new() -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .expect("failed to build HTTP client");
+
+        Self {
+            client,
+            semaphore: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    /// Build the Overpass QL query for a bounding box.
+    pub fn build_query(bbox: &BBox) -> String {
+        let bbox_str = bbox.to_overpass_string();
+        format!(
+            r#"[out:json][timeout:30];
+(
+  way["highway"]({bbox});
+  way["building"]({bbox});
+  way["natural"="water"]({bbox});
+  relation["natural"="water"]({bbox});
+  way["leisure"="park"]({bbox});
+  relation["leisure"="park"]({bbox});
+  way["landuse"="forest"]({bbox});
+  relation["landuse"="forest"]({bbox});
+);
+out body geom;"#,
+            bbox = bbox_str
+        )
+    }
+
+    /// Fetch raw Overpass JSON for a bounding box.
+    pub async fn fetch_bbox(
+        &self,
+        bbox: &BBox,
+    ) -> Result<serde_json::Value, MapError> {
+        // Acquire semaphore for rate limiting
+        let _permit = self
+            .semaphore
+            .acquire()
+            .await
+            .map_err(|_| MapError::RateLimited)?;
+
+        let query = Self::build_query(bbox);
+        debug!("Overpass query for bbox {}: {} bytes", bbox.to_overpass_string(), query.len());
+
+        let response = self
+            .client
+            .post(OVERPASS_API_URL)
+            .form(&[("data", &query)])
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            warn!("Overpass API returned {}: {}", status, &body[..body.len().min(200)]);
+            return Err(MapError::OverpassResponse(format!(
+                "HTTP {}: {}",
+                status,
+                &body[..body.len().min(200)]
+            )));
+        }
+
+        let json: serde_json::Value = response.json().await?;
+
+        // Check for Overpass-level errors
+        if let Some(remark) = json.get("remark") {
+            warn!("Overpass API remark: {}", remark);
+            return Err(MapError::OverpassResponse(
+                remark.as_str().unwrap_or("unknown error").to_string(),
+            ));
+        }
+
+        let element_count = json
+            .get("elements")
+            .and_then(|e| e.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        info!("Overpass returned {} elements for bbox {}", element_count, bbox.to_overpass_string());
+
+        // Rate limit delay after successful request
+        tokio::time::sleep(Duration::from_secs(RATE_LIMIT_DELAY_SECS)).await;
+
+        Ok(json)
+    }
+}
+
+impl Default for OverpassClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_contains_bbox() {
+        let bbox = BBox::new(51.51, -0.12, 51.52, -0.11).unwrap();
+        let query = OverpassClient::build_query(&bbox);
+        assert!(query.contains("51.51,-0.12,51.52,-0.11"));
+        assert!(query.contains(r#"way["highway"]"#));
+        assert!(query.contains(r#"way["building"]"#));
+        assert!(query.contains(r#"way["natural"="water"]"#));
+        assert!(query.contains(r#"way["leisure"="park"]"#));
+        assert!(query.contains(r#"way["landuse"="forest"]"#));
+        assert!(query.contains("out body geom;"));
+    }
+
+    #[test]
+    fn query_format_is_valid_overpass_ql() {
+        let bbox = BBox::new(51.51, -0.12, 51.52, -0.11).unwrap();
+        let query = OverpassClient::build_query(&bbox);
+        assert!(query.starts_with("[out:json]"));
+        assert!(query.ends_with("out body geom;"));
+    }
+}

--- a/server/crates/rmm-map/src/parser.rs
+++ b/server/crates/rmm-map/src/parser.rs
@@ -1,0 +1,329 @@
+use serde_json::Value;
+use tracing::debug;
+
+use crate::bbox::BBox;
+use crate::osm_types::{Building, LatLon, MapData, Polygon, Road};
+
+/// Road width lookup table (meters) by OSM highway type.
+fn road_width(highway_type: &str) -> f64 {
+    match highway_type {
+        "motorway" | "motorway_link" => 14.0,
+        "trunk" | "trunk_link" => 12.0,
+        "primary" | "primary_link" => 10.0,
+        "secondary" | "secondary_link" => 8.0,
+        "tertiary" | "tertiary_link" => 7.0,
+        "residential" | "living_street" | "unclassified" => 6.0,
+        "service" => 4.0,
+        "footway" | "cycleway" | "path" | "pedestrian" => 2.0,
+        _ => 6.0, // default
+    }
+}
+
+/// Extract geometry points from an Overpass element's `geometry` array.
+fn extract_geometry(element: &Value) -> Vec<LatLon> {
+    element
+        .get("geometry")
+        .and_then(|g| g.as_array())
+        .map(|coords| {
+            coords
+                .iter()
+                .filter_map(|c| {
+                    let lat = c.get("lat")?.as_f64()?;
+                    let lon = c.get("lon")?.as_f64()?;
+                    Some(LatLon::new(lat, lon))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Get a string tag value from an element's tags object.
+fn get_tag<'a>(element: &'a Value, key: &str) -> Option<&'a str> {
+    element.get("tags")?.get(key)?.as_str()
+}
+
+/// Get a numeric tag value (tries parsing the string).
+fn get_tag_f64(element: &Value, key: &str) -> Option<f64> {
+    let s = get_tag(element, key)?;
+    s.parse::<f64>().ok()
+}
+
+/// Estimate building height from OSM tags.
+fn building_height(element: &Value) -> f64 {
+    // Direct height tag
+    if let Some(h) = get_tag_f64(element, "height") {
+        return h;
+    }
+    // building:levels * 3 meters
+    if let Some(levels) = get_tag_f64(element, "building:levels") {
+        return levels * 3.0;
+    }
+    // Default
+    8.0
+}
+
+/// Parse Overpass JSON response into typed MapData.
+pub fn parse_overpass_json(json: &Value, bbox: BBox) -> MapData {
+    let elements = json
+        .get("elements")
+        .and_then(|e| e.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut roads = Vec::new();
+    let mut buildings = Vec::new();
+    let mut water = Vec::new();
+    let mut parks = Vec::new();
+    let mut forests = Vec::new();
+
+    for element in &elements {
+        let id = element.get("id").and_then(|i| i.as_i64()).unwrap_or(0);
+        let tags = element.get("tags");
+
+        if tags.is_none() {
+            continue;
+        }
+
+        let points = extract_geometry(element);
+
+        // Classify by tags
+        if let Some(highway) = get_tag(element, "highway") {
+            if points.len() >= 2 {
+                let oneway = get_tag(element, "oneway")
+                    .map(|v| v == "yes" || v == "1" || v == "true")
+                    .unwrap_or(false);
+                let lanes = get_tag(element, "lanes")
+                    .and_then(|v| v.parse::<u8>().ok())
+                    .unwrap_or(2);
+
+                roads.push(Road {
+                    id,
+                    highway_type: highway.to_string(),
+                    width: road_width(highway),
+                    name: get_tag(element, "name").map(String::from),
+                    oneway,
+                    lanes,
+                    points,
+                });
+            }
+        } else if get_tag(element, "building").is_some() {
+            if points.len() >= 3 {
+                buildings.push(Building {
+                    id,
+                    height: building_height(element),
+                    footprint: points,
+                });
+            }
+        } else if get_tag(element, "natural") == Some("water") {
+            if points.len() >= 3 {
+                water.push(Polygon {
+                    id,
+                    polygon_type: "water".to_string(),
+                    points,
+                });
+            }
+        } else if get_tag(element, "leisure") == Some("park") {
+            if points.len() >= 3 {
+                parks.push(Polygon {
+                    id,
+                    polygon_type: "park".to_string(),
+                    points,
+                });
+            }
+        } else if get_tag(element, "landuse") == Some("forest") {
+            if points.len() >= 3 {
+                forests.push(Polygon {
+                    id,
+                    polygon_type: "forest".to_string(),
+                    points,
+                });
+            }
+        }
+    }
+
+    debug!(
+        "Parsed: {} roads, {} buildings, {} water, {} parks, {} forests",
+        roads.len(),
+        buildings.len(),
+        water.len(),
+        parks.len(),
+        forests.len()
+    );
+
+    MapData {
+        roads,
+        buildings,
+        water,
+        parks,
+        forests,
+        bbox,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_overpass_json() -> Value {
+        json!({
+            "elements": [
+                {
+                    "type": "way",
+                    "id": 1001,
+                    "tags": {
+                        "highway": "residential",
+                        "name": "Test Street",
+                        "lanes": "2"
+                    },
+                    "geometry": [
+                        {"lat": 51.511, "lon": -0.116},
+                        {"lat": 51.512, "lon": -0.115},
+                        {"lat": 51.513, "lon": -0.114}
+                    ]
+                },
+                {
+                    "type": "way",
+                    "id": 1002,
+                    "tags": {
+                        "highway": "primary",
+                        "name": "Main Road",
+                        "oneway": "yes"
+                    },
+                    "geometry": [
+                        {"lat": 51.510, "lon": -0.120},
+                        {"lat": 51.510, "lon": -0.118}
+                    ]
+                },
+                {
+                    "type": "way",
+                    "id": 2001,
+                    "tags": {
+                        "building": "yes",
+                        "building:levels": "4"
+                    },
+                    "geometry": [
+                        {"lat": 51.511, "lon": -0.117},
+                        {"lat": 51.511, "lon": -0.116},
+                        {"lat": 51.512, "lon": -0.116},
+                        {"lat": 51.512, "lon": -0.117},
+                        {"lat": 51.511, "lon": -0.117}
+                    ]
+                },
+                {
+                    "type": "way",
+                    "id": 2002,
+                    "tags": {
+                        "building": "residential",
+                        "height": "15"
+                    },
+                    "geometry": [
+                        {"lat": 51.513, "lon": -0.115},
+                        {"lat": 51.513, "lon": -0.114},
+                        {"lat": 51.514, "lon": -0.114},
+                        {"lat": 51.513, "lon": -0.115}
+                    ]
+                },
+                {
+                    "type": "way",
+                    "id": 3001,
+                    "tags": {
+                        "natural": "water"
+                    },
+                    "geometry": [
+                        {"lat": 51.510, "lon": -0.115},
+                        {"lat": 51.510, "lon": -0.113},
+                        {"lat": 51.511, "lon": -0.113},
+                        {"lat": 51.510, "lon": -0.115}
+                    ]
+                },
+                {
+                    "type": "way",
+                    "id": 4001,
+                    "tags": {
+                        "leisure": "park"
+                    },
+                    "geometry": [
+                        {"lat": 51.514, "lon": -0.118},
+                        {"lat": 51.514, "lon": -0.116},
+                        {"lat": 51.515, "lon": -0.116},
+                        {"lat": 51.514, "lon": -0.118}
+                    ]
+                },
+                {
+                    "type": "way",
+                    "id": 5001,
+                    "tags": {
+                        "landuse": "forest"
+                    },
+                    "geometry": [
+                        {"lat": 51.515, "lon": -0.120},
+                        {"lat": 51.515, "lon": -0.118},
+                        {"lat": 51.516, "lon": -0.118},
+                        {"lat": 51.515, "lon": -0.120}
+                    ]
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn parses_roads() {
+        let bbox = BBox::new(51.510, -0.120, 51.516, -0.110).unwrap();
+        let data = parse_overpass_json(&sample_overpass_json(), bbox);
+        assert_eq!(data.roads.len(), 2);
+
+        let residential = data.roads.iter().find(|r| r.id == 1001).unwrap();
+        assert_eq!(residential.highway_type, "residential");
+        assert_eq!(residential.width, 6.0);
+        assert_eq!(residential.name.as_deref(), Some("Test Street"));
+        assert!(!residential.oneway);
+        assert_eq!(residential.lanes, 2);
+        assert_eq!(residential.points.len(), 3);
+
+        let primary = data.roads.iter().find(|r| r.id == 1002).unwrap();
+        assert_eq!(primary.highway_type, "primary");
+        assert_eq!(primary.width, 10.0);
+        assert!(primary.oneway);
+    }
+
+    #[test]
+    fn parses_buildings() {
+        let bbox = BBox::new(51.510, -0.120, 51.516, -0.110).unwrap();
+        let data = parse_overpass_json(&sample_overpass_json(), bbox);
+        assert_eq!(data.buildings.len(), 2);
+
+        let b1 = data.buildings.iter().find(|b| b.id == 2001).unwrap();
+        assert_eq!(b1.height, 12.0); // 4 levels * 3m
+
+        let b2 = data.buildings.iter().find(|b| b.id == 2002).unwrap();
+        assert_eq!(b2.height, 15.0); // explicit height tag
+    }
+
+    #[test]
+    fn parses_water_parks_forests() {
+        let bbox = BBox::new(51.510, -0.120, 51.516, -0.110).unwrap();
+        let data = parse_overpass_json(&sample_overpass_json(), bbox);
+        assert_eq!(data.water.len(), 1);
+        assert_eq!(data.parks.len(), 1);
+        assert_eq!(data.forests.len(), 1);
+    }
+
+    #[test]
+    fn road_width_lookup() {
+        assert_eq!(road_width("motorway"), 14.0);
+        assert_eq!(road_width("primary"), 10.0);
+        assert_eq!(road_width("residential"), 6.0);
+        assert_eq!(road_width("footway"), 2.0);
+        assert_eq!(road_width("unknown_type"), 6.0);
+    }
+
+    #[test]
+    fn empty_elements() {
+        let json = json!({"elements": []});
+        let bbox = BBox::new(51.51, -0.12, 51.52, -0.11).unwrap();
+        let data = parse_overpass_json(&json, bbox);
+        assert!(data.roads.is_empty());
+        assert!(data.buildings.is_empty());
+    }
+}

--- a/server/crates/rmm-server/Cargo.toml
+++ b/server/crates/rmm-server/Cargo.toml
@@ -13,6 +13,8 @@ tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenvy = "0.15"
+rmm-map = { path = "../rmm-map" }
+rmp-serde = "1"
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["json"] }

--- a/server/crates/rmm-server/src/config.rs
+++ b/server/crates/rmm-server/src/config.rs
@@ -3,6 +3,7 @@ use std::env;
 #[derive(Debug, Clone)]
 pub struct Config {
     pub port: u16,
+    pub cache_dir: String,
 }
 
 impl Config {
@@ -12,6 +13,8 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(3001),
+            cache_dir: env::var("RMM_CACHE_DIR")
+                .unwrap_or_else(|_| ".cache/maps".to_string()),
         }
     }
 }

--- a/server/crates/rmm-server/src/lib.rs
+++ b/server/crates/rmm-server/src/lib.rs
@@ -2,9 +2,33 @@ mod config;
 
 pub use config::Config;
 
-use axum::{routing::get, Json, Router};
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::{header, StatusCode},
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use rmm_map::{BBox, MapCache, MapError, OverpassClient};
+use serde::Deserialize;
 use serde_json::{json, Value};
 use tower_http::cors::CorsLayer;
+use tracing::{error, info};
+
+/// Shared application state.
+#[derive(Clone)]
+pub struct AppState {
+    pub overpass: OverpassClient,
+    pub cache: MapCache,
+}
+
+impl AppState {
+    pub fn new(overpass: OverpassClient, cache: MapCache) -> Self {
+        Self { overpass, cache }
+    }
+}
 
 async fn health() -> Json<Value> {
     Json(json!({ "status": "ok" }))
@@ -14,9 +38,132 @@ async fn ping() -> Json<Value> {
     Json(json!({ "status": "ok" }))
 }
 
-pub fn app() -> Router {
+#[derive(Debug, Deserialize)]
+struct MapQuery {
+    south: Option<f64>,
+    west: Option<f64>,
+    north: Option<f64>,
+    east: Option<f64>,
+}
+
+async fn get_map(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<MapQuery>,
+) -> impl IntoResponse {
+    // Validate all params are present
+    let (south, west, north, east) = match (params.south, params.west, params.north, params.east) {
+        (Some(s), Some(w), Some(n), Some(e)) => (s, w, n, e),
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "Missing required query parameters: south, west, north, east" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Create and validate bbox
+    let bbox = match BBox::new(south, west, north, east) {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+
+    // Validate size (100m to 2000m)
+    if let Err(e) = bbox.validate_size(100.0, 2000.0) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": e.to_string() })),
+        )
+            .into_response();
+    }
+
+    // Check cache
+    if let Some(cached_data) = state.cache.get(&bbox) {
+        info!("Serving cached map data for bbox {}", bbox.to_overpass_string());
+        return match rmp_serde::to_vec(&cached_data) {
+            Ok(bytes) => (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "application/x-msgpack")],
+                bytes,
+            )
+                .into_response(),
+            Err(e) => {
+                error!("Failed to serialize cached data: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "Internal server error" })),
+                )
+                    .into_response()
+            }
+        };
+    }
+
+    // Fetch from Overpass API
+    info!("Fetching map data from Overpass for bbox {}", bbox.to_overpass_string());
+    let overpass_json = match state.overpass.fetch_bbox(&bbox).await {
+        Ok(json) => json,
+        Err(e) => {
+            error!("Overpass API error: {}", e);
+            let (status, msg) = match &e {
+                MapError::OverpassRequest(_) => {
+                    (StatusCode::BAD_GATEWAY, "Failed to reach map data provider")
+                }
+                MapError::Timeout(_) => (StatusCode::GATEWAY_TIMEOUT, "Map data request timed out"),
+                MapError::RateLimited => {
+                    (StatusCode::TOO_MANY_REQUESTS, "Rate limited, please retry")
+                }
+                _ => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error"),
+            };
+            return (status, Json(json!({ "error": msg }))).into_response();
+        }
+    };
+
+    // Parse
+    let map_data = rmm_map::parse_overpass_json(&overpass_json, bbox);
+
+    // Cache the result (non-fatal if it fails)
+    if let Err(e) = state.cache.set(&bbox, &map_data) {
+        error!("Failed to cache map data: {}", e);
+    }
+
+    // Serialize to MessagePack
+    match rmp_serde::to_vec(&map_data) {
+        Ok(bytes) => {
+            info!(
+                "Serving {} bytes of map data ({} roads, {} buildings)",
+                bytes.len(),
+                map_data.roads.len(),
+                map_data.buildings.len()
+            );
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "application/x-msgpack")],
+                bytes,
+            )
+                .into_response()
+        }
+        Err(e) => {
+            error!("Failed to serialize map data: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "Internal server error" })),
+            )
+                .into_response()
+        }
+    }
+}
+
+pub fn app(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/api/ping", get(ping))
+        .route("/api/map", get(get_map))
         .layer(CorsLayer::permissive())
+        .with_state(state)
 }

--- a/server/crates/rmm-server/src/main.rs
+++ b/server/crates/rmm-server/src/main.rs
@@ -1,5 +1,8 @@
-use rmm_server::{app, Config};
 use std::net::SocketAddr;
+use std::sync::Arc;
+
+use rmm_map::{MapCache, OverpassClient};
+use rmm_server::{app, AppState, Config};
 use tracing::info;
 
 #[tokio::main]
@@ -7,16 +10,24 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "rmm_server=info".into()),
+                .unwrap_or_else(|_| "rmm_server=info,rmm_map=info".into()),
         )
         .init();
 
     dotenvy::dotenv().ok();
     let config = Config::from_env();
 
+    let overpass = OverpassClient::new();
+    let cache = MapCache::new(&config.cache_dir);
+    if let Err(e) = cache.ensure_dir() {
+        tracing::warn!("Failed to create cache directory: {}", e);
+    }
+
+    let state = Arc::new(AppState::new(overpass, cache));
+
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!("Server listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    axum::serve(listener, app()).await.unwrap();
+    axum::serve(listener, app(state)).await.unwrap();
 }

--- a/server/crates/rmm-server/tests/health.rs
+++ b/server/crates/rmm-server/tests/health.rs
@@ -1,12 +1,23 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
+
+use rmm_map::{MapCache, OverpassClient};
+use rmm_server::AppState;
+
+fn test_state() -> Arc<AppState> {
+    let overpass = OverpassClient::new();
+    let cache = MapCache::new(std::env::temp_dir().join("rmm-test-cache"));
+    Arc::new(AppState::new(overpass, cache))
+}
 
 async fn spawn_app() -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr: SocketAddr = listener.local_addr().unwrap();
     let base_url = format!("http://{}", addr);
 
+    let state = test_state();
     tokio::spawn(async move {
-        axum::serve(listener, rmm_server::app()).await.unwrap();
+        axum::serve(listener, rmm_server::app(state)).await.unwrap();
     });
 
     base_url

--- a/server/crates/rmm-server/tests/map_api.rs
+++ b/server/crates/rmm-server/tests/map_api.rs
@@ -1,0 +1,182 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use rmm_map::{BBox, Building, LatLon, MapCache, MapData, OverpassClient, Polygon, Road};
+use rmm_server::AppState;
+
+fn test_cache_dir() -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "rmm-map-api-test-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+fn test_state_with_cache(cache_dir: &std::path::Path) -> Arc<AppState> {
+    let overpass = OverpassClient::new();
+    let cache = MapCache::new(cache_dir);
+    Arc::new(AppState::new(overpass, cache))
+}
+
+/// Pre-seed cache with fixture data so tests don't hit the live API.
+fn seed_cache(cache: &MapCache, bbox: BBox) {
+    let data = MapData {
+        roads: vec![Road {
+            id: 1001,
+            highway_type: "residential".into(),
+            points: vec![
+                LatLon::new(51.511, -0.116),
+                LatLon::new(51.512, -0.115),
+            ],
+            width: 6.0,
+            name: Some("Test Street".into()),
+            oneway: false,
+            lanes: 2,
+        }],
+        buildings: vec![Building {
+            id: 2001,
+            footprint: vec![
+                LatLon::new(51.511, -0.117),
+                LatLon::new(51.511, -0.116),
+                LatLon::new(51.512, -0.116),
+                LatLon::new(51.511, -0.117),
+            ],
+            height: 12.0,
+        }],
+        water: vec![],
+        parks: vec![Polygon {
+            id: 4001,
+            points: vec![
+                LatLon::new(51.514, -0.118),
+                LatLon::new(51.514, -0.116),
+                LatLon::new(51.515, -0.116),
+                LatLon::new(51.514, -0.118),
+            ],
+            polygon_type: "park".into(),
+        }],
+        forests: vec![],
+        bbox,
+    };
+    cache.set(&bbox, &data).unwrap();
+}
+
+async fn spawn_app_with_cache(cache_dir: &std::path::Path) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    let base_url = format!("http://{}", addr);
+
+    let state = test_state_with_cache(cache_dir);
+    tokio::spawn(async move {
+        axum::serve(listener, rmm_server::app(state)).await.unwrap();
+    });
+
+    base_url
+}
+
+#[tokio::test]
+async fn map_missing_params_returns_400() {
+    let cache_dir = test_cache_dir();
+    let base = spawn_app_with_cache(&cache_dir).await;
+    let client = reqwest::Client::new();
+
+    // No params
+    let resp = client
+        .get(format!("{}/api/map", base))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // Partial params
+    let resp = client
+        .get(format!("{}/api/map?south=51.51&west=-0.12", base))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[tokio::test]
+async fn map_invalid_bbox_returns_400() {
+    let cache_dir = test_cache_dir();
+    let base = spawn_app_with_cache(&cache_dir).await;
+    let client = reqwest::Client::new();
+
+    // south > north
+    let resp = client
+        .get(format!(
+            "{}/api/map?south=51.52&west=-0.12&north=51.51&east=-0.11",
+            base
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[tokio::test]
+async fn map_too_small_bbox_returns_400() {
+    let cache_dir = test_cache_dir();
+    let base = spawn_app_with_cache(&cache_dir).await;
+    let client = reqwest::Client::new();
+
+    // Very tiny bbox (< 100m)
+    let resp = client
+        .get(format!(
+            "{}/api/map?south=51.510&west=-0.1100&north=51.5101&east=-0.1099",
+            base
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}
+
+#[tokio::test]
+async fn map_returns_msgpack_from_cache() {
+    let cache_dir = test_cache_dir();
+    let bbox = BBox::new(51.510, -0.120, 51.515, -0.110).unwrap();
+
+    // Pre-seed the cache
+    let cache = MapCache::new(&cache_dir);
+    seed_cache(&cache, bbox);
+
+    let base = spawn_app_with_cache(&cache_dir).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!(
+            "{}/api/map?south=51.510&west=-0.120&north=51.515&east=-0.110",
+            base
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(content_type, "application/x-msgpack");
+
+    // Deserialize the MessagePack response
+    let bytes = resp.bytes().await.unwrap();
+    let data: MapData = rmp_serde::from_slice(&bytes).unwrap();
+    assert_eq!(data.roads.len(), 1);
+    assert_eq!(data.buildings.len(), 1);
+    assert_eq!(data.parks.len(), 1);
+    assert_eq!(data.roads[0].name.as_deref(), Some("Test Street"));
+
+    let _ = std::fs::remove_dir_all(&cache_dir);
+}


### PR DESCRIPTION
## Summary

Complete map data pipeline from real-world OpenStreetMap data to 3D rendered scene:

- **Server: `rmm-map` crate** — New Rust crate with Overpass API client, OSM JSON parser (roads, buildings, water, parks, forests), disk-based MessagePack cache with SHA256 keys and 1-week TTL
- **Server: `/api/map` endpoint** — Accepts bbox query params, validates size (100m-2000m), returns parsed MapData as MessagePack with proper error handling
- **Client: `map/` module** — Local tangent plane projection, road geometry builder (triangle strips merged by type), building builder (extruded footprints batch-merged), nature builder (InstancedMesh trees with Poisson disk sampling), water/terrain builders
- **Client: Three.js scene** — Full 3D scene with OrbitControls, directional + ambient + hemisphere lighting, sky blue background, loading indicator

### Closes
Closes #8, closes #9, closes #10, closes #11, closes #12, closes #13, closes #14, closes #15, closes #16, closes #17

## Test plan

- [x] cargo test - 22 server tests pass (bbox validation, parser, cache, API endpoint)
- [x] pnpm test - 18 client tests pass (projection, road builder, building builder)
- [x] pnpm typecheck - No TypeScript errors
- [x] pnpm lint - No ESLint errors
- [x] pnpm build - Client builds to dist/
- [x] All 4 lefthook pre-commit hooks pass
- [ ] Manual: Start server + client, verify central London renders in 3D with roads, buildings, trees

Generated with Claude Code