### PR TITLE
fix: correct Z-inversion in Shape-based geometry

### DIFF
--- a/client/src/map/BuildingBuilder.ts
+++ b/client/src/map/BuildingBuilder.ts
@@ -15,11 +15,13 @@ function buildBuildingGeometry(
 ): THREE.BufferGeometry | null {
   if (footprint.length < 3) return null;
 
-  // Create a 2D shape from the footprint (using X, Z as the shape coordinates)
+  // Create a 2D shape from the footprint.
+  // Shape lives in XY plane; rotateX(-PI/2) maps shape-Y → world -Z,
+  // so we negate z here to compensate (double-negation → correct world Z).
   const shape = new THREE.Shape();
-  shape.moveTo(footprint[0].x, footprint[0].z);
+  shape.moveTo(footprint[0].x, -footprint[0].z);
   for (let i = 1; i < footprint.length; i++) {
-    shape.lineTo(footprint[i].x, footprint[i].z);
+    shape.lineTo(footprint[i].x, -footprint[i].z);
   }
   shape.closePath();
 

--- a/client/src/map/NatureBuilder.ts
+++ b/client/src/map/NatureBuilder.ts
@@ -139,10 +139,12 @@ function buildParkGround(
 ): THREE.Mesh | null {
   if (polygon.length < 3) return null;
 
+  // Negate z when feeding into Shape's Y to compensate for rotateX(-PI/2)
+  // which maps shape-Y → world -Z (double-negation → correct world Z).
   const shape = new THREE.Shape();
-  shape.moveTo(polygon[0].x, polygon[0].z);
+  shape.moveTo(polygon[0].x, -polygon[0].z);
   for (let i = 1; i < polygon.length; i++) {
-    shape.lineTo(polygon[i].x, polygon[i].z);
+    shape.lineTo(polygon[i].x, -polygon[i].z);
   }
   shape.closePath();
 

--- a/client/src/map/WaterBuilder.ts
+++ b/client/src/map/WaterBuilder.ts
@@ -19,10 +19,12 @@ export function buildWater(
     const projected = proj.projectAll(poly.points);
     if (projected.length < 3) continue;
 
+    // Negate z when feeding into Shape's Y to compensate for rotateX(-PI/2)
+    // which maps shape-Y → world -Z (double-negation → correct world Z).
     const shape = new THREE.Shape();
-    shape.moveTo(projected[0].x, projected[0].z);
+    shape.moveTo(projected[0].x, -projected[0].z);
     for (let i = 1; i < projected.length; i++) {
-      shape.lineTo(projected[i].x, projected[i].z);
+      shape.lineTo(projected[i].x, -projected[i].z);
     }
     shape.closePath();
 


### PR DESCRIPTION
## Summary

- Buildings, park grounds, and water polygons were rendering mirrored on the Z axis relative to roads
- Root cause: `THREE.Shape` lives in the XY plane — when `rotateX(-PI/2)` is applied, shape-Y maps to world **-Z**, but our projected Z coordinates were fed directly into shape-Y without negation
- Roads were unaffected because `RoadBuilder` places vertices directly in world coordinates (no Shape/rotation involved)

**Fix**: Negate `z` when creating Shape points (`shape.moveTo(x, -z)`), so the rotation's negation cancels out → correct world Z.

## Test plan

- [x] `pnpm test` — 18 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: buildings and parks now align with roads on the map

Generated with Claude Code